### PR TITLE
build: convert manifest to modern nimble format

### DIFF
--- a/isaac.nimble
+++ b/isaac.nimble
@@ -1,7 +1,5 @@
-[Package]
-name: "isaac"
-version: "0.1.3"
-author: "Xored Software, Inc."
-description: "ISAAC PRNG implementation"
-license: "MIT"
-srcDir: "src"
+version       = "0.1.3"
+author        = "Xored Software, Inc."
+description   = "ISAAC PRNG implementation"
+license       = "MIT"
+srcDir        = "src"


### PR DESCRIPTION
The INI-style ([Package]) manifest makes nimble 0.22.x vNext dependency validation extract an empty version for this package, which drops any requirer (uuids) from the resolution graph and fails lock-mode solves. Content is unchanged.